### PR TITLE
feat: add wake lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "nosleep.js": "^0.12.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.15",
     "@types/node": "^12.0.0",
+    "@types/nosleep.js": "^0.9.0",
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
     "@types/react-router-dom": "^5.1.7",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,14 +4,17 @@ import {
   Route,
 } from 'react-router-dom';
 import { ModalProvider } from 'styled-react-modal';
+import GlobalStyles from './components/GlobalStyles';
 import ModalBackground from './components/ModalBackground';
 import routes from './config/routes';
 import RoundScreen from './screens/RoundScreen';
 
+// TODO: Test GlobalStyles component
 // TODO: Test ModalProvider component
 // TODO: Analyze if the router will be needed further
 const App = (): JSX.Element => (
   <div className="app">
+    <GlobalStyles />
     <ModalProvider backgroundComponent={ModalBackground}>
       <Router>
         <Switch>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import GlobalStyles from './components/GlobalStyles';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 
 ReactDOM.render(
   <React.StrictMode>
-    <GlobalStyles />
     <App />
   </React.StrictMode>,
   document.getElementById('root')

--- a/src/screens/RoundScreen.tsx
+++ b/src/screens/RoundScreen.tsx
@@ -8,6 +8,7 @@ import SlimSpinArrow from '../components/SlimSpinArrow';
 import StartButton from '../components/StartButton';
 import TapScreenImage from '../components/TapScreenImage';
 import unoColorsAnimation from '../styles/animations/unoColorsAnimation';
+import wakeLock from '../utils/wakeLock';
 
 // TODO: Test state & actions
 // TODO: Test round direction arrow props
@@ -21,6 +22,11 @@ const RoundScreen = (): JSX.Element => {
   
   // Actions
   const closeModal = (): void => setIsOpen(false);
+  const enableWakeLock = (): Promise<void> => wakeLock.enable();
+  const start = async (): Promise<void> => {
+    await enableWakeLock();
+    closeModal();
+  };
   const toggleDirection = (): void => {
     // TODO: Analyze if the modal can be moved outside the screen component to
     // avoid having to check if the instructions (or any) modal is open
@@ -38,7 +44,7 @@ const RoundScreen = (): JSX.Element => {
         <ModalTitle>Instructions</ModalTitle>
         <ModalText>Tap <b>anywhere</b> in the screen to change the arrow's direction.</ModalText>
         <TapScreenImage />
-        <StartButton onClick={closeModal}>
+        <StartButton onClick={start}>
           Got it!
         </StartButton>
       </InstructionsModal>

--- a/src/utils/__tests__/wakeLock.test.ts
+++ b/src/utils/__tests__/wakeLock.test.ts
@@ -1,0 +1,12 @@
+import NoSleep from 'nosleep.js';
+import wakeLock from '../wakeLock';
+
+describe('wakeLock', (): void => {
+  it('should return a NoSleep instance', (): void => {
+    // Assert
+    expect(wakeLock).toBeInstanceOf(NoSleep);
+    expect(wakeLock).toHaveProperty('enable');
+    expect(wakeLock).toHaveProperty('disable');
+    expect(wakeLock).toHaveProperty('isEnabled');
+  });
+});

--- a/src/utils/wakeLock.ts
+++ b/src/utils/wakeLock.ts
@@ -1,0 +1,6 @@
+import NoSleep from 'nosleep.js';
+
+// Create class instance
+const wakeLock = new NoSleep();
+
+export default wakeLock;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,6 +1806,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/nosleep.js@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@types/nosleep.js/-/nosleep.js-0.9.0.tgz#57c9f322c88f18a9559942d26c64c4ab4de9a9d2"
+  integrity sha512-RM0MRsjpfBsgbcmmC32ZE+zaxc8VMwc56UemKCl/eb0eL2t5tRb2ioxOXLlpyOZ770CF8X0osxqcjV3Hf9UWlw==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -7624,6 +7629,11 @@ normalize-url@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
+
+nosleep.js@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/nosleep.js/-/nosleep.js-0.12.0.tgz#a01fddab2c13af357d673928b1f40a9013a4dc08"
+  integrity sha512-9d1HbpKLh3sdWlhXMhU6MMH+wQzKkrgfRkYV0EBdvt99YJfj0ilCJrWRDYG2130Tm4GXbEoTCx5b34JSaP+HhA==
 
 npm-run-path@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
### Description

Now that all initial components are in place, the only missing feature is the Wake Lock, which is responsible for keeping the screen turned on while the user is using the application. This way, the user is not forced to tap on the screen to keep it alive, it's enabled automatically once the user press the `<StartButton />`.

Additionally, the `<GlobalStyles />` component was moved from the `index.tsx` to the `<App />` component, so the `index.tsx` looks clean.

Current versions:

- nosleep.js: `^0.12.0`
- @types/nosleep.js: `^0.9.0`

### Evidence

_Wake Lock message shown in the console only in development environment_
![image](https://user-images.githubusercontent.com/20128985/109655274-dca7b080-7b41-11eb-86b6-3ea3738e8a7d.png)