### PR TITLE
cicd: add GitHub pages deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,35 @@
+name: '[CD] Deploy to GitHub Pages'
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Deploy
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - name: Run tests
+        run: yarn test --ci --watchAll=false
+      - name: Build source code
+        run: yarn build
+      - name: Retrieve application version
+        id: application-version
+        uses: martinbeentjes/npm-get-version-action@master
+      - name: Deploy
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          build_dir: build
+          commit_message: v${{steps.application-version.outputs.current-version}}
+          keep_history: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "slime",
   "version": "1.0.0",
+  "homepage": "https://squaro.github.io/slime/",
   "private": true,
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
### Description

Now that the application has a **Continuous Integration** pipeline that processes automatically the code to release a new version, we must define a **Continuous Deployment** pipeline that uploads the built application into [GitHub Pages](https://pages.github.com/).

For this, we decided to use two open source GitHub Actions that helps us through this process:

- [martinbeentjes/npm-get-version-action](https://github.com/martinbeentjes/npm-get-version-action): retrieves the **version** value from the `package.json`.
- [crazy-max/ghaction-github-pages](https://github.com/crazy-max/ghaction-github-pages): uploads the application's build into **GitHub Pages** using the application version as commit message. Additionally, it was configured to keep history in case we need to rollback to a previous version.

Additionally, we updated the `homepage` property from the `package.json` to match the repository's URL for GitHub Pages.

### Evidence

N/A