### PR TITLE
fix: update round screen components positioning

### DIFF
--- a/src/screens/RoundScreen.tsx
+++ b/src/screens/RoundScreen.tsx
@@ -21,19 +21,15 @@ const RoundScreen: React.FunctionComponent = () => {
     await enableWakeLock();
     closeModal();
   };
-  const toggleDirection = (): void => {
-    // TODO: Analyze if the modal can be moved outside the screen component to
-    // avoid having to check if the instructions (or any) modal is open
-    if (!isOpen) {
-      setDirection(!direction);
-    }
-  };
+  const toggleDirection = (): void => setDirection(!direction);
 
   return (
-    <Screen onClick={toggleDirection} data-testid="round-screen">
-      <RoundDirectionArrow direction={direction} />
+    <React.Fragment>
+      <Screen onClick={toggleDirection} data-testid="round-screen">
+        <RoundDirectionArrow direction={direction} />
+      </Screen>
       <InstructionsModal isOpen={isOpen} onClose={start} />
-    </Screen>
+    </React.Fragment>
   );
 };
 

--- a/src/screens/RoundScreen.tsx
+++ b/src/screens/RoundScreen.tsx
@@ -21,7 +21,13 @@ const RoundScreen: React.FunctionComponent = () => {
     await enableWakeLock();
     closeModal();
   };
-  const toggleDirection = (): void => setDirection(!direction);
+  const toggleDirection = (): void => {
+    // The logic should be validated anyways besides the fact that the 
+    // user can't click on the screen if the instructions modal is open
+    if (!isOpen) {
+      setDirection(!direction);
+    }
+  };
 
   return (
     <React.Fragment>

--- a/src/screens/RoundScreen.tsx
+++ b/src/screens/RoundScreen.tsx
@@ -11,30 +11,30 @@ const RoundScreen: React.FunctionComponent = () => {
   // Store direction value
   //  * Left = false
   //  * Right = true (default)
-  const [direction, setDirection] = useState(true);
-  const [isOpen, setIsOpen] = useState(true);
+  const [roundDirection, setRoundDirection] = useState(true);
+  const [isInstructionsModalOpen, setIsInstructionsModalOpen] = useState(true);
   
   // Actions
-  const closeModal = (): void => setIsOpen(false);
+  const closeInstructionsModal = (): void => setIsInstructionsModalOpen(false);
   const enableWakeLock = (): Promise<void> => wakeLock.enable();
   const start = async (): Promise<void> => {
     await enableWakeLock();
-    closeModal();
+    closeInstructionsModal();
   };
   const toggleDirection = (): void => {
     // The logic should be validated anyways besides the fact that the 
     // user can't click on the screen if the instructions modal is open
-    if (!isOpen) {
-      setDirection(!direction);
+    if (!isInstructionsModalOpen) {
+      setRoundDirection(!roundDirection);
     }
   };
 
   return (
     <React.Fragment>
       <Screen onClick={toggleDirection} data-testid="round-screen">
-        <RoundDirectionArrow direction={direction} />
+        <RoundDirectionArrow direction={roundDirection} />
       </Screen>
-      <InstructionsModal isOpen={isOpen} onClose={start} />
+      <InstructionsModal isOpen={isInstructionsModalOpen} onClose={start} />
     </React.Fragment>
   );
 };


### PR DESCRIPTION
### Description

When we first thought the `<RoundScreen />` component, we knew that it was kind of weird having the `<InstructionsModal />` component within the `<Screen />` component, because when clicking on the modal, the `toggleDirection()` method was triggered. That's why we added a validation to check if the Instructions Modal was open before triggering the action.

When working on this task, we decided to create a `<React.Fragment />` to render the `<Screen />` and `<InstructionsModal />` components at the same level. After making that change, we noticed that it was impossible for the `toggleDirection()` to trigger if the Instructions Modal was open, which is good, so we removed the condition to check if the Instructions Modal was open to change the round's direction.

Later on, playing around with the UI Tests, we noticed that it wouldn't make sense to remove the validation because we need to ensure that the scenario of clicking the Screen with the Instructions Modal visible will not trigger the `toggleDirection()` method, and the only way to do that is to not rely on the "UI components" but in the logic underneath. So, we decided to add the validation back and we also added a comment to clarify the intention of the validation.

The bottom line is that we ensure the user to close the Instructions Modal first, then he can interact with the Round Screen. In case the modal doesn't work properly, we expect them to report the issue _(TBD)_ instead of using the broken application anyways.

Additionally, we renamed the state's variables to improve code readability.