### PR TITLE
feat: add Wake Lock modal

### DIFF
--- a/src/components/InstructionsModal.tsx
+++ b/src/components/InstructionsModal.tsx
@@ -14,6 +14,7 @@ export const Wrapper = Modal.styled`
   background-color: #424242;
   border: 2px solid #0DBB13;
   border-radius: 15px;
+  user-select: none;
 `;
 
 export const Title = styled.h3`
@@ -37,7 +38,6 @@ export const Button = styled.button`
   border-radius: 10px;
   box-shadow: 3px 3px 6px rgba(0,0,0,0.3);
   background-color: #0DBB13;
-  outline: none;
   border: 0 none;
   font-weight: bold;
   font-size: 16px;

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -4,6 +4,7 @@ const Screen = styled.section`
   width: 100%;
   height: 100%;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
 `;

--- a/src/components/WakeLockMessage.tsx
+++ b/src/components/WakeLockMessage.tsx
@@ -7,6 +7,7 @@ const Wrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  user-select: none;
 
   @media only screen and (min-width: 768px) {
     flex-direction: row;

--- a/src/components/WakeLockMessage.tsx
+++ b/src/components/WakeLockMessage.tsx
@@ -1,0 +1,66 @@
+import styled, { css } from 'styled-components';
+
+const Wrapper = styled.div`
+  width: 100%;
+  height: 50px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  @media only screen and (min-width: 768px) {
+    flex-direction: row;
+  }
+`;
+
+type MessageProps = {
+  warning: boolean;
+};
+
+const Message = styled.p<MessageProps>`
+  margin: 0;
+  font-size: 12px;
+  text-align: center;
+  color: #757575;
+
+  ${({ warning }) => warning && css`
+    color: #8F8C29;
+  `}
+`;
+
+const Button = styled.a`
+  padding: 2px 4px;
+  outline: none;
+  font-size: 12px;
+  color: #757575;
+  background-color: transparent;
+  text-decoration: underline;
+  cursor: pointer;
+
+  &:active,
+  &:hover {
+    color: #626262;
+  }
+`;
+
+type WakeLockMessageProps = {
+  isWakeLockEnabled: boolean;
+  onClick: () => void;
+};
+
+function WakeLockMessage({ isWakeLockEnabled, onClick }: WakeLockMessageProps) {
+  const showWarning = !isWakeLockEnabled;
+
+  return (
+    <Wrapper>
+      <Message warning={showWarning}>
+        The screen will {showWarning && `not`} remain active while using the application.
+      </Message>
+      <Button onClick={onClick}>
+        Learn more
+      </Button>
+    </Wrapper>
+  );
+}
+
+export default WakeLockMessage;

--- a/src/components/WakeLockMessage.tsx
+++ b/src/components/WakeLockMessage.tsx
@@ -34,7 +34,6 @@ const Button = styled.a`
   outline: none;
   font-size: 12px;
   color: #757575;
-  background-color: transparent;
   text-decoration: underline;
   cursor: pointer;
 
@@ -54,10 +53,10 @@ function WakeLockMessage({ isWakeLockEnabled, onClick }: WakeLockMessageProps) {
 
   return (
     <Wrapper>
-      <Message warning={showWarning}>
+      <Message warning={showWarning} data-testid="wake-lock-message">
         The screen will {showWarning && `not`} remain active while using the application.
       </Message>
-      <Button onClick={onClick}>
+      <Button onClick={onClick} data-testid="wake-lock-message-button">
         Learn more
       </Button>
     </Wrapper>

--- a/src/components/WakeLockMessage.tsx
+++ b/src/components/WakeLockMessage.tsx
@@ -31,7 +31,6 @@ const Message = styled.p<MessageProps>`
 
 const Button = styled.a`
   padding: 2px 4px;
-  outline: none;
   font-size: 12px;
   color: #757575;
   text-decoration: underline;

--- a/src/components/WakeLockModal.tsx
+++ b/src/components/WakeLockModal.tsx
@@ -54,10 +54,10 @@ export const Button = styled.button`
   }
 `;
 
-interface WakeLockModalProps {
+type WakeLockModalProps = {
   isOpen: boolean;
   onClose: () => void;
-}
+};
 
 function WakeLock({ isOpen, onClose }: WakeLockModalProps) {
   return (

--- a/src/components/WakeLockModal.tsx
+++ b/src/components/WakeLockModal.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import styled from 'styled-components';
+import Modal from 'styled-react-modal';
+
+export const Wrapper = Modal.styled`
+  width: 80vmin;
+  max-width: 288px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: #424242;
+  border: 2px solid #0D58BB;
+  border-radius: 15px;
+`;
+
+export const Title = styled.h3`
+  margin-top: 0;
+  text-transform: uppercase;
+`;
+
+export const Text = styled.p`
+  margin-top: 0;
+  text-align: left;
+`;
+
+export const Clarification = styled.p`
+  margin-top: 0;
+  font-size: 12px;
+  font-style: italic;
+  text-align: left;
+  color: #9E9E9E;
+`;
+
+export const Button = styled.button`
+  width: 100%;
+  padding: 20px 72px;
+  margin-top: 12px;
+  border-radius: 10px;
+  box-shadow: 3px 3px 6px rgba(0,0,0,0.3);
+  background-color: #0D58BB;
+  outline: none;
+  border: 0 none;
+  font-weight: bold;
+  font-size: 16px;
+  color: #FFFFFF;
+  text-transform: uppercase;
+  cursor: pointer;
+
+  &:active {
+    background-color: #104D9E;
+    box-shadow: 3px 3px 6px rgba(0,0,0,0.2);
+  }
+`;
+
+interface WakeLockProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const WakeLock: React.FunctionComponent<WakeLockProps> = ({ isOpen, onClose }) => (
+  <Wrapper isOpen={isOpen}>
+    <Title>Wake Lock</Title>
+    <Text>The Wake Lock feature prevents the device from <b>dimming</b> and <b>locking</b> the screen while using the application.</Text>
+    <Text>You can determine whether your phone allows this feature or not by looking at the bottom of the screen</Text>
+    <Clarification>If your phone doesn't allow the wake lock feature, soon you will be able to report the issue.</Clarification>
+    <Button onClick={onClose}>Close</Button>
+  </Wrapper>
+);
+
+export default WakeLock;

--- a/src/components/WakeLockModal.tsx
+++ b/src/components/WakeLockModal.tsx
@@ -25,7 +25,7 @@ export const Text = styled.p`
   text-align: left;
 `;
 
-export const Clarification = styled.p`
+export const TextClarification = styled.p`
   margin-top: 0;
   font-size: 12px;
   font-style: italic;
@@ -65,7 +65,7 @@ function WakeLock({ isOpen, onClose }: WakeLockModalProps) {
       <Title data-testid="wake-lock-modal-title">Wake Lock</Title>
       <Text data-testid="wake-lock-modal-feature-text">The Wake Lock feature prevents the device from <b>dimming</b> and <b>locking</b> the screen while using the application.</Text>
       <Text data-testid="wake-lock-modal-phone-text">You can determine whether your phone allows this feature or not by looking at the bottom of the screen.</Text>
-      <Clarification data-testid="wake-lock-modal-clarification">If your phone doesn't allow the wake lock feature, soon you will be able to report the issue.</Clarification>
+      <TextClarification data-testid="wake-lock-modal-clarification-text">If your phone doesn't allow the wake lock feature, soon you will be able to report the issue.</TextClarification>
       <Button onClick={onClose} data-testid="wake-lock-modal-button">Close</Button>
     </Wrapper>
   );

--- a/src/components/WakeLockModal.tsx
+++ b/src/components/WakeLockModal.tsx
@@ -25,11 +25,9 @@ export const Text = styled.p`
   text-align: left;
 `;
 
-export const TextClarification = styled.p`
-  margin-top: 0;
+export const TextClarification = styled(Text)`
   font-size: 12px;
   font-style: italic;
-  text-align: left;
   color: #9E9E9E;
 `;
 

--- a/src/components/WakeLockModal.tsx
+++ b/src/components/WakeLockModal.tsx
@@ -62,8 +62,8 @@ function WakeLock({ isOpen, onClose }: WakeLockModalProps) {
     <Wrapper isOpen={isOpen} data-testid="wake-lock-modal">
       <Title data-testid="wake-lock-modal-title">Wake Lock</Title>
       <Text data-testid="wake-lock-modal-feature-text">The Wake Lock feature prevents the device from <b>dimming</b> and <b>locking</b> the screen while using the application.</Text>
-      <Text data-testid="wake-lock-modal-phone-text">You can determine whether your phone allows this feature or not by looking at the bottom of the screen.</Text>
-      <TextClarification data-testid="wake-lock-modal-clarification-text">If your phone doesn't allow the wake lock feature, soon you will be able to report the issue.</TextClarification>
+      <Text data-testid="wake-lock-modal-phone-text">You can determine whether your phone supports this feature or not by looking at the bottom of the screen.</Text>
+      <TextClarification data-testid="wake-lock-modal-clarification-text">If your phone doesn't support the wake lock feature, soon you will be able to report the issue.</TextClarification>
       <Button onClick={onClose} data-testid="wake-lock-modal-button">Close</Button>
     </Wrapper>
   );

--- a/src/components/WakeLockModal.tsx
+++ b/src/components/WakeLockModal.tsx
@@ -13,6 +13,7 @@ export const Wrapper = Modal.styled`
   background-color: #424242;
   border: 2px solid #0D58BB;
   border-radius: 15px;
+  user-select: none;
 `;
 
 export const Title = styled.h3`
@@ -38,7 +39,6 @@ export const Button = styled.button`
   border-radius: 10px;
   box-shadow: 3px 3px 6px rgba(0,0,0,0.3);
   background-color: #0D58BB;
-  outline: none;
   border: 0 none;
   font-weight: bold;
   font-size: 16px;

--- a/src/components/WakeLockModal.tsx
+++ b/src/components/WakeLockModal.tsx
@@ -54,19 +54,21 @@ export const Button = styled.button`
   }
 `;
 
-interface WakeLockProps {
+interface WakeLockModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-const WakeLock: React.FunctionComponent<WakeLockProps> = ({ isOpen, onClose }) => (
-  <Wrapper isOpen={isOpen}>
-    <Title>Wake Lock</Title>
-    <Text>The Wake Lock feature prevents the device from <b>dimming</b> and <b>locking</b> the screen while using the application.</Text>
-    <Text>You can determine whether your phone allows this feature or not by looking at the bottom of the screen</Text>
-    <Clarification>If your phone doesn't allow the wake lock feature, soon you will be able to report the issue.</Clarification>
-    <Button onClick={onClose}>Close</Button>
-  </Wrapper>
-);
+function WakeLock({ isOpen, onClose }: WakeLockModalProps) {
+  return (
+    <Wrapper isOpen={isOpen} data-testid="wake-lock-modal">
+      <Title data-testid="wake-lock-modal-title">Wake Lock</Title>
+      <Text data-testid="wake-lock-modal-feature-text">The Wake Lock feature prevents the device from <b>dimming</b> and <b>locking</b> the screen while using the application.</Text>
+      <Text data-testid="wake-lock-modal-phone-text">You can determine whether your phone allows this feature or not by looking at the bottom of the screen.</Text>
+      <Clarification data-testid="wake-lock-modal-clarification">If your phone doesn't allow the wake lock feature, soon you will be able to report the issue.</Clarification>
+      <Button onClick={onClose} data-testid="wake-lock-modal-button">Close</Button>
+    </Wrapper>
+  );
+};
 
 export default WakeLock;

--- a/src/components/__tests__/WakeLockMessage.test.tsx
+++ b/src/components/__tests__/WakeLockMessage.test.tsx
@@ -23,7 +23,7 @@ test("renders a different wake lock message when it's disabled", () => {
   expect(messageText).toHaveStyle(`color: #8F8C29;`);
 });
 
-test("calls the on click callback when pressed the button", () => {
+test('calls the on click callback when pressed the button', () => {
   const enabled = false;
   const onClick = jest.fn();
 

--- a/src/components/__tests__/WakeLockMessage.test.tsx
+++ b/src/components/__tests__/WakeLockMessage.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import WakeLockMessage from '../WakeLockMessage';
+
+test("renders a wake lock message when it's enabled", () => {
+  const enabled = true;
+  const onClick = jest.fn();
+
+  render(<WakeLockMessage isWakeLockEnabled={enabled} onClick={onClick} />);
+
+  const messageText = screen.getByTestId('wake-lock-message');
+  expect(messageText).toHaveTextContent('The screen will remain active while using the application.');
+  expect(messageText).not.toHaveStyle(`color: #8F8C29;`);
+});
+
+test("renders a different wake lock message when it's disabled", () => {
+  const enabled = false;
+  const onClick = jest.fn();
+
+  render(<WakeLockMessage isWakeLockEnabled={enabled} onClick={onClick} />);
+
+  const messageText = screen.getByTestId('wake-lock-message');
+  expect(messageText).toHaveTextContent('The screen will not remain active while using the application.');
+  expect(messageText).toHaveStyle(`color: #8F8C29;`);
+});
+
+test("calls the on click callback when pressed the button", () => {
+  const enabled = false;
+  const onClick = jest.fn();
+
+  render(<WakeLockMessage isWakeLockEnabled={enabled} onClick={onClick} />);
+
+  const messageButton = screen.getByTestId('wake-lock-message-button');
+  fireEvent.click(messageButton);
+  expect(onClick).toHaveBeenCalled();
+});

--- a/src/components/__tests__/WakeLockModal.test.tsx
+++ b/src/components/__tests__/WakeLockModal.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ModalProvider } from 'styled-react-modal';
+import WakeLockModal from '../WakeLockModal';
+
+test("doesn't render the wake lock modal", () => {
+  const isOpen = false;
+  const onClose = jest.fn();
+
+  render(
+    <ModalProvider>
+      <WakeLockModal isOpen={isOpen} onClose={onClose} />
+    </ModalProvider>
+  );
+
+  expect(screen.queryByTestId('wake-lock-modal')).not.toBeInTheDocument();
+});
+
+test('renders the wake lock modal', () => {
+  const isOpen = true;
+  const onClose = jest.fn();
+
+  render(
+    <ModalProvider>
+      <WakeLockModal isOpen={isOpen} onClose={onClose} />
+    </ModalProvider>
+  );
+
+  expect(screen.queryByTestId('wake-lock-modal')).toBeInTheDocument();
+  expect(screen.getByTestId('wake-lock-modal-feature-text')).toHaveTextContent('The Wake Lock feature prevents the device from dimming and locking the screen while using the application.');
+  expect(screen.getByTestId('wake-lock-modal-phone-text')).toHaveTextContent('You can determine whether your phone allows this feature or not by looking at the bottom of the screen.');
+  expect(screen.getByTestId('wake-lock-modal-clarification')).toHaveTextContent('If your phone doesn\'t allow the wake lock feature, soon you will be able to report the issue.');
+  expect(screen.getByTestId('wake-lock-modal-button')).toHaveTextContent('Close');
+});
+
+test('calls the on close callback when pressed the button', async () => {
+  const isOpen = true;
+  const onClose = jest.fn();
+
+  render(
+    <ModalProvider>
+      <WakeLockModal isOpen={isOpen} onClose={onClose} />
+    </ModalProvider>
+  );
+
+  const modalButton = screen.getByTestId('wake-lock-modal-button');
+  fireEvent.click(modalButton);
+  expect(onClose).toHaveBeenCalled();
+});

--- a/src/components/__tests__/WakeLockModal.test.tsx
+++ b/src/components/__tests__/WakeLockModal.test.tsx
@@ -28,7 +28,7 @@ test('renders the wake lock modal', () => {
   expect(screen.queryByTestId('wake-lock-modal')).toBeInTheDocument();
   expect(screen.getByTestId('wake-lock-modal-feature-text')).toHaveTextContent('The Wake Lock feature prevents the device from dimming and locking the screen while using the application.');
   expect(screen.getByTestId('wake-lock-modal-phone-text')).toHaveTextContent('You can determine whether your phone allows this feature or not by looking at the bottom of the screen.');
-  expect(screen.getByTestId('wake-lock-modal-clarification')).toHaveTextContent('If your phone doesn\'t allow the wake lock feature, soon you will be able to report the issue.');
+  expect(screen.getByTestId('wake-lock-modal-clarification-text')).toHaveTextContent('If your phone doesn\'t allow the wake lock feature, soon you will be able to report the issue.');
   expect(screen.getByTestId('wake-lock-modal-button')).toHaveTextContent('Close');
 });
 

--- a/src/screens/RoundScreen.tsx
+++ b/src/screens/RoundScreen.tsx
@@ -1,8 +1,20 @@
 import React, { useState } from 'react';
+import styled from 'styled-components';
 import InstructionsModal from '../components/InstructionsModal';
 import RoundDirectionArrow from '../components/RoundDirectionArrow';
 import Screen from '../components/Screen';
+import WakeLockMessage from '../components/WakeLockMessage';
+import WakeLockModal from '../components/WakeLockModal';
 import wakeLock from '../utils/wakeLock';
+
+const RoundDirectionArrowWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
 
 // TODO: Test state & actions
 // TODO: Test round direction arrow props
@@ -13,9 +25,12 @@ const RoundScreen: React.FunctionComponent = () => {
   //  * Right = true (default)
   const [roundDirection, setRoundDirection] = useState(true);
   const [isInstructionsModalOpen, setIsInstructionsModalOpen] = useState(true);
+  const [isWakeLockModalOpen, setIsWakeLockModalOpen] = useState(false);
   
   // Actions
   const closeInstructionsModal = (): void => setIsInstructionsModalOpen(false);
+  const closeWakeLockModal = (): void => setIsWakeLockModalOpen(false);
+  const openWakeLockModal = (): void => setIsWakeLockModalOpen(true);
   const enableWakeLock = (): Promise<void> => wakeLock.enable();
   const start = async (): Promise<void> => {
     await enableWakeLock();
@@ -31,10 +46,14 @@ const RoundScreen: React.FunctionComponent = () => {
 
   return (
     <React.Fragment>
-      <Screen onClick={toggleDirection} data-testid="round-screen">
-        <RoundDirectionArrow direction={roundDirection} />
+      <Screen data-testid="round-screen">
+        <RoundDirectionArrowWrapper onClick={toggleDirection}>
+          <RoundDirectionArrow direction={roundDirection} />
+        </RoundDirectionArrowWrapper>
+        <WakeLockMessage isWakeLockEnabled={wakeLock.isEnabled} onClick={openWakeLockModal} />
       </Screen>
       <InstructionsModal isOpen={isInstructionsModalOpen} onClose={start} />
+      <WakeLockModal isOpen={isWakeLockModalOpen} onClose={closeWakeLockModal} />
     </React.Fragment>
   );
 };

--- a/src/screens/RoundScreen.tsx
+++ b/src/screens/RoundScreen.tsx
@@ -8,8 +8,8 @@ import WakeLockModal from '../components/WakeLockModal';
 import wakeLock from '../utils/wakeLock';
 
 const RoundDirectionArrowWrapper = styled.div`
+  flex-grow: 1;
   width: 100%;
-  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/screens/RoundScreen.tsx
+++ b/src/screens/RoundScreen.tsx
@@ -5,6 +5,7 @@ import RoundDirectionArrow from '../components/RoundDirectionArrow';
 import Screen from '../components/Screen';
 import WakeLockMessage from '../components/WakeLockMessage';
 import WakeLockModal from '../components/WakeLockModal';
+import logger from '../utils/logger';
 import wakeLock from '../utils/wakeLock';
 
 const RoundDirectionArrowWrapper = styled.div`
@@ -29,13 +30,27 @@ const RoundScreen: React.FunctionComponent = () => {
   
   // Actions
   const closeInstructionsModal = (): void => setIsInstructionsModalOpen(false);
+
   const closeWakeLockModal = (): void => setIsWakeLockModalOpen(false);
+
   const openWakeLockModal = (): void => setIsWakeLockModalOpen(true);
-  const enableWakeLock = (): Promise<void> => wakeLock.enable();
+
+  // TODO: Move to wakeLock.ts to delegate responsability
+  const enableWakeLock = async (): Promise<void> => {
+    try {
+      logger.logInfo('[WakeLock] Locking screen...');
+      await wakeLock.enable();
+      logger.logInfo('[WakeLock] Screen locked!');
+    } catch (err) {
+      logger.logError('[WakeLock] An error occurred while locking the screen.', err);
+    }
+  };
+
   const start = async (): Promise<void> => {
     await enableWakeLock();
     closeInstructionsModal();
   };
+
   const toggleDirection = (): void => {
     // The logic should be validated anyways besides the fact that the 
     // user can't click on the screen if the instructions modal is open

--- a/src/screens/RoundScreen.tsx
+++ b/src/screens/RoundScreen.tsx
@@ -15,6 +15,9 @@ const RoundDirectionArrowWrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+
+  // Solves the overflow issue when clicking the 'Learn more' button
+  overflow: hidden;
 `;
 
 // TODO: Test state & actions

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,7 @@
+const logger = {
+  logError: console.error,
+  logInfo: console.log,
+  logWarn: console.warn,
+};
+
+export default logger;


### PR DESCRIPTION
### Description

After implementing the Wake Lock feature, we noticed that there was no message nor indicator that let the user know if the Wake Lock is working properly or not. That's why we decided to add a message at the bottom of the screen that shows if the Wake Lock is enabled or not. Additionally, we added a `'Learn more'` button that opens a modal to explain further **how the feature works** and **what to do if it's not working**.

Additionally, we made a few changes to the `<RoundScreen />` to place the `<WakeLockMessage />` at the bottom of the screen without having issues with the `<RoundDirectionArrow />`.

Last but not least, we applied minor improvements to the application's accessibility (a11y).

### Evidence

_Wake Lock message shown if the Wake Lock feature is not working_
![image](https://user-images.githubusercontent.com/20128985/110526770-fa05ed00-80f4-11eb-9f34-c31b44a7b414.png)

_Wake Lock message shown on mobile screens_
![image](https://user-images.githubusercontent.com/20128985/110526814-05f1af00-80f5-11eb-9558-f136a6646425.png)

_Wake Lock modal shown on mobile screens_
![image](https://user-images.githubusercontent.com/20128985/110526862-12760780-80f5-11eb-8e07-22886f43cfed.png)

_Wake Lock message shown on desktop/laptop screens_
![image](https://user-images.githubusercontent.com/20128985/110526925-24f04100-80f5-11eb-9ff6-685c3a8df53a.png)

_Wake Lock modal shown on desktop/laptop screens_
![image](https://user-images.githubusercontent.com/20128985/110526910-215cba00-80f5-11eb-8606-f3d958c58bfc.png)
