### PR TITLE
feat: add spanish language

### DIFF
--- a/src/config/__tests__/routes.test.ts
+++ b/src/config/__tests__/routes.test.ts
@@ -1,9 +1,6 @@
 import routes from '../routes';
 
-describe('routes', (): void => {
-  it('should contain the "home" property pointing to "/"', (): void => {
-    // Assert
-    expect(routes).toHaveProperty('home');
-    expect(routes.home).toEqual('/');
-  });
+test('should contain the "home" property pointing to "/"', () => {
+  expect(routes).toHaveProperty('home');
+  expect(routes.home).toEqual('/');
 });

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -1,11 +1,11 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import en from '../locales/en';
+import { en, es } from '../locales';
 
 i18n
   .use(initReactI18next)
   .init({
-    lng: 'en',
+    lng: 'es',
     fallbackLng: 'en',
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default
@@ -13,6 +13,9 @@ i18n
     resources: {
       en: {
         translation: en,
+      },
+      es: {
+        translation: es,
       },
     },
   });

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -5,7 +5,7 @@ import { en, es } from '../locales';
 i18n
   .use(initReactI18next)
   .init({
-    lng: 'es',
+    lng: 'en',
     fallbackLng: 'en',
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -1,6 +1,7 @@
 import i18n from 'i18next';
-import { initReactI18next } from 'react-i18next';
-import { en, es } from '../locales';
+import { initReactI18next, } from 'react-i18next';
+import * as locales from '../locales';
+import { mapLocalesToResources } from '../utils/i18n';
 
 i18n
   .use(initReactI18next)
@@ -10,14 +11,7 @@ i18n
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default
     },
-    resources: {
-      en: {
-        translation: en,
-      },
-      es: {
-        translation: es,
-      },
-    },
+    resources: mapLocalesToResources(locales),
   });
 
 export default i18n;

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1,0 +1,20 @@
+import strings from '../config/strings';
+
+const getWakeLockMessage = (enabled: boolean) =>
+  `La pantalla ${!enabled ? ` no ` : ''}permanecerá activa mientras se utiliza la aplicación.`;
+
+const es: typeof strings = {
+  INSTRUCTIONS_MODAL_CLOSE_BUTTON: 'Entendido!',
+  INSTRUCTIONS_MODAL_TEXT: 'Presiona en <0>cualquier sector</0> de la pantalla para cambiar la dirección de la ronda.',
+  INSTRUCTIONS_MODAL_TITLE: 'Instrucciones',
+  WAKE_LOCK_MESSAGE_ACTION_BUTTON: 'Más información',
+  WAKE_LOCK_MESSAGE_ENABLED: getWakeLockMessage(true),
+  WAKE_LOCK_MESSAGE_DISABLED: getWakeLockMessage(false),
+  WAKE_LOCK_MODAL_CLARIFICATION: 'Si su teléfono no admite la funcionalidad Wake Lock, pronto podrá informar el problema.',
+  WAKE_LOCK_MODAL_CLOSE_BUTTON: 'Cerrar',
+  WAKE_LOCK_MODAL_FEATURE: 'La funcionalidad Wake Lock impide que el dispositivo se <0>oscurezca</0> y <0>bloquee</0> la pantalla mientras se utiliza la aplicación.',
+  WAKE_LOCK_MODAL_PHONE: 'Puedes determinar si tu teléfono admite esta funcionalidad o no mirando la parte inferior de la pantalla.',
+  WAKE_LOCK_MODAL_TITLE: 'Wake Lock',
+};
+
+export default es;

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -12,7 +12,7 @@ const es: typeof strings = {
   WAKE_LOCK_MESSAGE_DISABLED: getWakeLockMessage(false),
   WAKE_LOCK_MODAL_CLARIFICATION: 'Si su teléfono no admite la funcionalidad Wake Lock, pronto podrá informar el problema.',
   WAKE_LOCK_MODAL_CLOSE_BUTTON: 'Cerrar',
-  WAKE_LOCK_MODAL_FEATURE: 'La funcionalidad Wake Lock impide que el dispositivo se <0>oscurezca</0> y <0>bloquee</0> la pantalla mientras se utiliza la aplicación.',
+  WAKE_LOCK_MODAL_FEATURE: 'La funcionalidad Wake Lock impide que el dispositivo <0>oscurezca</0> y <0>bloquee</0> la pantalla mientras se utiliza la aplicación.',
   WAKE_LOCK_MODAL_PHONE: 'Puedes determinar si tu teléfono admite esta funcionalidad o no mirando la parte inferior de la pantalla.',
   WAKE_LOCK_MODAL_TITLE: 'Wake Lock',
 };

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,0 +1,2 @@
+export { default as en } from './en';
+export { default as es } from './es';

--- a/src/utils/__tests__/i18n.test.ts
+++ b/src/utils/__tests__/i18n.test.ts
@@ -1,7 +1,7 @@
 import { Resource } from 'i18next';
 import { mapLocalesToResources } from '../i18n';
 
-test('should map a single locale to resources properly', (): void => {
+test('should map a single locale to resources properly', () => {
   const en = {
     FOO: 'foo',
     BAR: 'bar',
@@ -17,7 +17,7 @@ test('should map a single locale to resources properly', (): void => {
   expect(resources.en.translation).toMatchObject(en);
 });
 
-test('should map multiple locales to resources properly', (): void => {
+test('should map multiple locales to resources properly', () => {
   const en = {
     FOO: 'foo',
     BAR: 'bar',

--- a/src/utils/__tests__/i18n.test.ts
+++ b/src/utils/__tests__/i18n.test.ts
@@ -1,0 +1,42 @@
+import { Resource } from 'i18next';
+import { mapLocalesToResources } from '../i18n';
+
+test('should map a single locale to resources properly', (): void => {
+  const en = {
+    FOO: 'foo',
+    BAR: 'bar',
+  };
+  const locales = {
+    en,
+  };
+
+  const resources: Resource = mapLocalesToResources(locales);
+
+  expect(resources).toHaveProperty('en');
+  expect(resources.en).toHaveProperty('translation');
+  expect(resources.en.translation).toMatchObject(en);
+});
+
+test('should map multiple locales to resources properly', (): void => {
+  const en = {
+    FOO: 'foo',
+    BAR: 'bar',
+  };
+  const es = {
+    BAZ: 'foo',
+    QUX: 'qux',
+  };
+  const locales = {
+    en,
+    es,
+  };
+
+  const resources: Resource = mapLocalesToResources(locales);
+
+  expect(resources).toHaveProperty('en');
+  expect(resources.en).toHaveProperty('translation');
+  expect(resources.en.translation).toMatchObject(en);
+  expect(resources).toHaveProperty('es');
+  expect(resources.es).toHaveProperty('translation');
+  expect(resources.es.translation).toMatchObject(es);
+});

--- a/src/utils/__tests__/wakeLock.test.ts
+++ b/src/utils/__tests__/wakeLock.test.ts
@@ -1,12 +1,9 @@
 import NoSleep from 'nosleep.js';
 import wakeLock from '../wakeLock';
 
-describe('wakeLock', (): void => {
-  it('should return a NoSleep instance', (): void => {
-    // Assert
-    expect(wakeLock).toBeInstanceOf(NoSleep);
-    expect(wakeLock).toHaveProperty('enable');
-    expect(wakeLock).toHaveProperty('disable');
-    expect(wakeLock).toHaveProperty('isEnabled');
-  });
+test('should return a NoSleep instance', () => {
+  expect(wakeLock).toBeInstanceOf(NoSleep);
+  expect(wakeLock).toHaveProperty('enable');
+  expect(wakeLock).toHaveProperty('disable');
+  expect(wakeLock).toHaveProperty('isEnabled');
 });

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,0 +1,12 @@
+import { ResourceLanguage, Resource } from 'i18next';
+
+export const mapLocalesToResources = (locales: ResourceLanguage) => Object.keys(locales).reduce(
+  (accumulator: Resource, key: string) => {
+    accumulator[key] = {
+      translation: (locales as ResourceLanguage)[key],
+    };
+
+    return accumulator;
+  },
+  {} as Resource,
+);


### PR DESCRIPTION
### Description

After adding the `i18n` configuration to support multiple languages, we decided to add the Spanish translation as the first supported language besides English.

These translations will be available for the users later through the **Languages Modal**. Additionally, we will be adding the `LanguageDetector` library to use the user's device language rather than defaulting always to English.

Additionally, we updated some unit tests to use the new format, which includes:

- Remove unnecessary `describe()` wrappers
- Use `test()` instead of `it()`
- Use **implicit** return types for each test

### Evidence

_Spanish translations for the Instructions Modal_
![image](https://user-images.githubusercontent.com/20128985/111875413-6647e280-8978-11eb-8aea-eca7ea20e988.png)

_Spanish translations for the WakeLock Modal_
![image](https://user-images.githubusercontent.com/20128985/111875409-621bc500-8978-11eb-907f-9652f5e4618f.png)