### PR TITLE
feat: add language button

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
+    "@styled-icons/bootstrap": "^10.29.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/components/GlobalStyles.tsx
+++ b/src/components/GlobalStyles.tsx
@@ -1,6 +1,12 @@
 import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyles = createGlobalStyle`
+  *,
+  *:before,
+  *:after {
+    box-sizing: border-box;
+  }
+
   html,
   body,
   #root {

--- a/src/components/LanguageButton.tsx
+++ b/src/components/LanguageButton.tsx
@@ -1,0 +1,69 @@
+import { Globe } from '@styled-icons/bootstrap/Globe';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+const Wrapper = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 12px;
+  background-color: transparent;
+  border-radius: 5px;
+  border: 0 none;
+  outline: none;
+  cursor: pointer;
+  user-select: none;
+`;
+
+const GlobeIcon = styled(Globe)`
+  color: #757575;
+
+  ${Wrapper}:focus &,
+  ${Wrapper}:hover & {
+    color: #BDBDBD;
+  }
+`;
+
+const Separator = styled.div`
+  width: 3px;
+  height: 3px;
+  margin: 0 6px;
+  background-color: #757575;
+  border-radius: 3px;
+
+  ${Wrapper}:focus &,
+  ${Wrapper}:hover & {
+    background-color: #BDBDBD;
+  }
+`;
+
+const Language = styled.span`
+  color: #757575;
+  font-size: 12px;
+
+  ${Wrapper}:focus &,
+  ${Wrapper}:hover & {
+    color: #BDBDBD;
+  }
+`;
+
+type LanguageButtonProps = {
+  onClick: () => void;
+};
+
+function LanguageButton({ onClick }: LanguageButtonProps) {
+  const { i18n } = useTranslation();
+  const shortLanguage = i18n.language.substr(0, 2).toUpperCase();
+
+  return (
+    <Wrapper onClick={onClick}>
+      <GlobeIcon size="16" />
+      <Separator />
+      <Language>
+        {shortLanguage}
+      </Language>
+    </Wrapper>
+  );
+}
+
+export default LanguageButton;

--- a/src/components/LanguageButton.tsx
+++ b/src/components/LanguageButton.tsx
@@ -56,10 +56,10 @@ function LanguageButton({ onClick }: LanguageButtonProps) {
   const shortLanguage = i18n.language.substr(0, 2).toUpperCase();
 
   return (
-    <Wrapper onClick={onClick}>
-      <GlobeIcon size="16" />
-      <Separator />
-      <Language>
+    <Wrapper onClick={onClick} data-testid="language-button">
+      <GlobeIcon size="16" data-testid="language-button-globe-icon" />
+      <Separator data-testid="language-button-separator" />
+      <Language data-testid="language-button-short-language">
         {shortLanguage}
       </Language>
     </Wrapper>

--- a/src/components/__tests__/LanguageButton.test.tsx
+++ b/src/components/__tests__/LanguageButton.test.tsx
@@ -1,12 +1,12 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { defaultLanguage } from '../../config/languages';
 import LanguageButton from '../LanguageButton';
 
 test('renders the language button with the proper language', () => {
   const onClick = jest.fn();
 
-  // TODO: Get short language from i18n rather
-  // hardcoding the value here.
-  const defaultShortLanguage = 'EN';
+  // TODO: Get short language from i18n rather than using the default language.
+  const defaultShortLanguage = defaultLanguage.substring(0, 2).toUpperCase();
 
   render(
     <LanguageButton onClick={onClick} />

--- a/src/components/__tests__/LanguageButton.test.tsx
+++ b/src/components/__tests__/LanguageButton.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import LanguageButton from '../LanguageButton';
+
+test('renders the language button with the proper language', () => {
+  const onClick = jest.fn();
+
+  // TODO: Get short language from i18n rather
+  // hardcoding the value here.
+  const defaultShortLanguage = 'EN';
+
+  render(
+    <LanguageButton onClick={onClick} />
+  );
+
+  expect(screen.queryByTestId('language-button')).toBeInTheDocument();
+  expect(screen.queryByTestId('language-button-globe-icon')).toBeInTheDocument();
+  expect(screen.queryByTestId('language-button-separator')).toBeInTheDocument();
+
+  const shortLanguage = screen.getByTestId('language-button-short-language');
+  expect(shortLanguage.textContent).toEqual(defaultShortLanguage);
+});
+
+test('calls the on click callback when pressed the button', async () => {
+  const onClick = jest.fn();
+
+  render(
+    <LanguageButton onClick={onClick} />
+  );
+
+  const closeButton = screen.getByTestId('language-button');
+  fireEvent.click(closeButton);
+  expect(onClick).toHaveBeenCalled();
+});

--- a/src/components/__tests__/__snapshots__/GlobalStyles.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/GlobalStyles.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`GlobalStyles should load global styles 1`] = `
     data-styled="active"
     data-styled-version="5.2.1"
   >
+    *,*:before,*:after{box-sizing:border-box;}
     html,body,#root{width:100%;height:100%;margin:0;padding:0;overflow:hidden;}
     body{color:#fff;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI','Roboto','Oxygen','Ubuntu','Cantarell','Fira Sans','Droid Sans','Helvetica Neue',sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;}
     code{font-family:source-code-pro,Menlo,Monaco,Consolas,'Courier New',monospace;}

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -3,13 +3,14 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next, } from 'react-i18next';
 import * as locales from '../locales';
 import { mapLocalesToResources, updateDOMLanguage } from '../utils/i18n';
+import { defaultLanguage } from './languages';
 
 // Initialize i18n
 i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    fallbackLng: 'en',
+    fallbackLng: defaultLanguage,
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default
     },

--- a/src/config/languages.ts
+++ b/src/config/languages.ts
@@ -1,11 +1,14 @@
 import strings from './strings';
 
+// Default
+export const defaultLanguage = 'en-US';
+
 export type Language = {
   code: string;
   string: string;
 };
 
-// List of available languages
+// List of languages
 const languages: Language[] = [
   {
     code: 'en-US',

--- a/src/screens/RoundScreen.tsx
+++ b/src/screens/RoundScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import LanguageButton from '../components/LanguageButton';
 import InstructionsModal from '../components/InstructionsModal';
 import LanguageModal from '../components/LanguageModal';
 import RoundDirectionArrow from '../components/RoundDirectionArrow';
@@ -8,6 +9,15 @@ import WakeLockMessage from '../components/WakeLockMessage';
 import WakeLockModal from '../components/WakeLockModal';
 import logger from '../utils/logger';
 import wakeLock from '../utils/wakeLock';
+
+const Header = styled.div`
+  width: 100%;
+  height: 48px;
+  padding: 0 4px;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+`;
 
 const RoundDirectionArrowWrapper = styled.div`
   flex-grow: 1;
@@ -40,6 +50,8 @@ const RoundScreen: React.FunctionComponent = () => {
   const closeLanguageModal = (): void => setIsLanguageModalOpen(false);
   
   const closeWakeLockModal = (): void => setIsWakeLockModalOpen(false);
+
+  const openLanguageModal = (): void => setIsLanguageModalOpen(true);
 
   const openWakeLockModal = (): void => setIsWakeLockModalOpen(true);
 
@@ -76,6 +88,9 @@ const RoundScreen: React.FunctionComponent = () => {
   return (
     <React.Fragment>
       <Screen data-testid="round-screen">
+        <Header>
+          <LanguageButton onClick={openLanguageModal}/>
+        </Header>
         <RoundDirectionArrowWrapper onClick={toggleDirection}>
           <RoundDirectionArrow direction={roundDirection} />
         </RoundDirectionArrowWrapper>

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,6 +4,7 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 import React from 'react';
+import { defaultLanguage as mockLanguage } from './config/languages';
 
 jest.mock('react-i18next', () => ({
   // this mock makes sure any components using the translate hook can use it without a warning being shown
@@ -11,7 +12,7 @@ jest.mock('react-i18next', () => ({
     return {
       t: (str: string) => str,
       i18n: {
-        language: 'en-US',
+        language: mockLanguage,
         changeLanguage: () => new Promise(() => {}),
       },
     };

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -11,6 +11,7 @@ jest.mock('react-i18next', () => ({
     return {
       t: (str: string) => str,
       i18n: {
+        language: 'en-US',
         changeLanguage: () => new Promise(() => {}),
       },
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1105,7 +1105,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.12.0", "@babel/runtime@^7.13.6":
+"@babel/runtime@^7.10.5", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.13.6":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
   integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
@@ -1168,7 +1168,7 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@emotion/is-prop-valid@^0.8.8":
+"@emotion/is-prop-valid@^0.8.7", "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -1717,6 +1717,22 @@
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+"@styled-icons/bootstrap@^10.29.0":
+  version "10.29.0"
+  resolved "https://registry.yarnpkg.com/@styled-icons/bootstrap/-/bootstrap-10.29.0.tgz#0f727581013ab020e7d8bb2e158430b0ee3b266d"
+  integrity sha512-B6UhU2p8zpAKBMLDmxgoXlHbODrvz8MM8nRLIGpCIWJ8rMen6a1FQJj22vKOL4ppC4A0hy2/IgBEc1gVwOdwiw==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    "@styled-icons/styled-icon" "^10.6.0"
+
+"@styled-icons/styled-icon@^10.6.0":
+  version "10.6.3"
+  resolved "https://registry.yarnpkg.com/@styled-icons/styled-icon/-/styled-icon-10.6.3.tgz#eae0e5e18fd601ac47e821bb9c2e099810e86403"
+  integrity sha512-/A95L3peioLoWFiy+/eKRhoQ9r/oRrN/qzbSX4hXU1nGP2rUXcX3LWUhoBNAOp9Rw38ucc/4ralY427UUNtcGQ==
+  dependencies:
+    "@babel/runtime" "^7.10.5"
+    "@emotion/is-prop-valid" "^0.8.7"
 
 "@surma/rollup-plugin-off-main-thread@^1.1.1":
   version "1.4.2"


### PR DESCRIPTION
### Description

This pull request adds the `<LanguageButton />` component into the Round Screen to allow the user change the current application's language. Additionally, it shows up the current language shorten in uppercase (e.g. `en-US` -> `EN`).

Additionally, we configured the `defaultLanguage` variable as `en-US` under `./config/languages.ts` to use the same value across files.

Last but not least, we added a new Global Style that configures the `box-sizing: border-box` for all elements (`*`), including their `:after` and `:before` selectors.

Current versions:

- @styled-icons/bootstrap: `^10.29.0`

### Evidence

_Language Button demo_
![language-button](https://user-images.githubusercontent.com/20128985/112521992-e48ef500-8d7b-11eb-8535-056d5ef2da81.gif)

_Language Button shown in mobile devices_
![image](https://user-images.githubusercontent.com/20128985/112522549-89a9cd80-8d7c-11eb-8234-3fedf1221819.png)

_Language Button shown in wide-screen devices_
![image](https://user-images.githubusercontent.com/20128985/112521796-ae517580-8d7b-11eb-893e-ed9f4d7fb2d5.png)