### PR TITLE
refactor: move modal's buttons to styled component

### DIFF
--- a/src/components/InstructionsModal.tsx
+++ b/src/components/InstructionsModal.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import Modal from 'styled-react-modal';
 import { ReactComponent as TapScreen } from '../assets/instructions/tap-screen.svg';
 import strings from '../config/strings';
+import ModalButton from './ModalButton.styles';
 
 const Wrapper = Modal.styled`
   width: 80vmin;
@@ -32,23 +33,11 @@ const TapScreenImage = styled(TapScreen)`
   margin: 12px;
 `;
 
-const Button = styled.button`
-  width: 100%;
-  padding: 20px 72px;
-  margin-top: 12px;
-  border-radius: 10px;
-  box-shadow: 3px 3px 6px rgba(0,0,0,0.3);
+const CloseButton = styled(ModalButton)`
   background-color: #0DBB13;
-  border: 0 none;
-  font-weight: bold;
-  font-size: 16px;
-  color: #FFFFFF;
-  text-transform: uppercase;
-  cursor: pointer;
 
   &:active {
     background-color: #0DAA12;
-    box-shadow: 3px 3px 6px rgba(0,0,0,0.2);
   }
 `;
 
@@ -71,9 +60,9 @@ function InstructionsModal({ isOpen, onClose }: InstructionsModalProps) {
         <Trans i18nKey={strings.INSTRUCTIONS_MODAL_TEXT} components={[<strong />]} />
       </Text>
       <TapScreenImage data-testid="instructions-modal-tap-screen-image" />
-      <Button onClick={onClose} data-testid="instructions-modal-close-button">
+      <CloseButton onClick={onClose} data-testid="instructions-modal-close-button">
         {closeButtonText}
-      </Button>
+      </CloseButton>
     </Wrapper>
   );
 };

--- a/src/components/LanguageModal.tsx
+++ b/src/components/LanguageModal.tsx
@@ -5,6 +5,7 @@ import languages, { Language } from '../config/languages';
 import strings from '../config/strings';
 import { updateDOMLanguage } from '../utils/i18n';
 import LanguageItem from './LanguageItem';
+import ModalButton from './ModalButton.styles';
 
 const Wrapper = Modal.styled`
   width: 80vmin;
@@ -33,23 +34,11 @@ const LanguagesList = styled.div`
   padding: 16px 0 24px 0;
 `;
 
-const Button = styled.button`
-  width: 100%;
-  padding: 20px 72px;
-  margin-top: 12px;
-  border-radius: 10px;
-  box-shadow: 3px 3px 6px rgba(0,0,0,0.3);
+const CloseButton = styled(ModalButton)`
   background-color: #DC7E13;
-  border: 0 none;
-  font-weight: bold;
-  font-size: 16px;
-  color: #FFFFFF;
-  text-transform: uppercase;
-  cursor: pointer;
 
   &:active {
     background-color: #B9701C;
-    box-shadow: 3px 3px 6px rgba(0,0,0,0.2);
   }
 `;
 
@@ -102,9 +91,9 @@ function LanguageModal({ isOpen, onClose }: LanguageModalProps) {
           />
         ))}
       </LanguagesList>
-      <Button onClick={onClose} data-testid="language-modal-close-button">
+      <CloseButton onClick={onClose} data-testid="language-modal-close-button">
         {closeButtonText}
-      </Button>
+      </CloseButton>
     </Wrapper>
   );
 };

--- a/src/components/ModalButton.styles.tsx
+++ b/src/components/ModalButton.styles.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+const ModalButton = styled.button`
+  width: 100%;
+  padding: 20px 72px;
+  margin-top: 12px;
+  border-radius: 10px;
+  box-shadow: 3px 3px 6px rgba(0,0,0,0.3);
+  border: 0 none;
+  font-weight: bold;
+  font-size: 16px;
+  color: #FFFFFF;
+  text-transform: uppercase;
+  cursor: pointer;
+
+  &:active {
+    box-shadow: 3px 3px 6px rgba(0,0,0,0.2);
+  }
+`;
+
+export default ModalButton;

--- a/src/components/ModalButton.styles.tsx
+++ b/src/components/ModalButton.styles.tsx
@@ -12,9 +12,10 @@ const ModalButton = styled.button`
   color: #FFFFFF;
   text-transform: uppercase;
   cursor: pointer;
+  outline: none;
 
   &:active {
-    box-shadow: 3px 3px 6px rgba(0,0,0,0.2);
+    box-shadow: 3px 3px 6px rgba(0,0,0,0.5);
   }
 `;
 

--- a/src/components/ModalButton.styles.tsx
+++ b/src/components/ModalButton.styles.tsx
@@ -5,6 +5,7 @@ const ModalButton = styled.button`
   padding: 20px 72px;
   margin-top: 12px;
   border-radius: 10px;
+  background-color: #9E9E9E;
   box-shadow: 3px 3px 6px rgba(0,0,0,0.3);
   border: 0 none;
   font-weight: bold;

--- a/src/components/WakeLockModal.tsx
+++ b/src/components/WakeLockModal.tsx
@@ -2,6 +2,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import Modal from 'styled-react-modal';
 import strings from '../config/strings';
+import ModalButton from './ModalButton.styles';
 
 const Wrapper = Modal.styled`
   width: 80vmin;
@@ -33,23 +34,11 @@ const SupportText = styled(Text)`
   color: #9E9E9E;
 `;
 
-const Button = styled.button`
-  width: 100%;
-  padding: 20px 72px;
-  margin-top: 12px;
-  border-radius: 10px;
-  box-shadow: 3px 3px 6px rgba(0,0,0,0.3);
+const CloseButton = styled(ModalButton)`
   background-color: #0D58BB;
-  border: 0 none;
-  font-weight: bold;
-  font-size: 16px;
-  color: #FFFFFF;
-  text-transform: uppercase;
-  cursor: pointer;
 
   &:active {
     background-color: #104D9E;
-    box-shadow: 3px 3px 6px rgba(0,0,0,0.2);
   }
 `;
 
@@ -79,9 +68,9 @@ function WakeLockModal({ isOpen, onClose }: WakeLockModalProps) {
       <SupportText data-testid="wake-lock-modal-clarification-text">
         {supportText}
       </SupportText>
-      <Button onClick={onClose} data-testid="wake-lock-modal-close-button">
+      <CloseButton onClick={onClose} data-testid="wake-lock-modal-close-button">
         {closeButtonText}
-      </Button>
+      </CloseButton>
     </Wrapper>
   );
 };


### PR DESCRIPTION
### Description

This pull request refactors the `<InstructionsModal />`, `<LanguageModal />`, and `<WakeLockModal />` components to use the new styled `<ModalButton />` component, which is shared across components and contains the common styles for a modal's button.

Additionally, all modal's buttons were renamed to `<CloseButton />` to have a more appropriate name according it's functionality.