### PR TITLE
refactor: move modal's titles to styled component

### DIFF
--- a/src/components/InstructionsModal.tsx
+++ b/src/components/InstructionsModal.tsx
@@ -29,7 +29,7 @@ const TapScreenImage = styled(TapScreen)`
   margin: 12px;
 `;
 
-const CloseButton = styled(ModalButton)`
+const ModalCloseButton = styled(ModalButton)`
   background-color: #0DBB13;
 
   &:active {
@@ -56,9 +56,9 @@ function InstructionsModal({ isOpen, onClose }: InstructionsModalProps) {
         <Trans i18nKey={strings.INSTRUCTIONS_MODAL_TEXT} components={[<strong />]} />
       </Text>
       <TapScreenImage data-testid="instructions-modal-tap-screen-image" />
-      <CloseButton onClick={onClose} data-testid="instructions-modal-close-button">
+      <ModalCloseButton onClick={onClose} data-testid="instructions-modal-close-button">
         {closeButtonText}
-      </CloseButton>
+      </ModalCloseButton>
     </Wrapper>
   );
 };

--- a/src/components/InstructionsModal.tsx
+++ b/src/components/InstructionsModal.tsx
@@ -4,6 +4,7 @@ import Modal from 'styled-react-modal';
 import { ReactComponent as TapScreen } from '../assets/instructions/tap-screen.svg';
 import strings from '../config/strings';
 import ModalButton from './ModalButton.styles';
+import ModalTitle from './ModalTitle.styles';
 
 const Wrapper = Modal.styled`
   width: 80vmin;
@@ -17,11 +18,6 @@ const Wrapper = Modal.styled`
   border: 2px solid #0DBB13;
   border-radius: 15px;
   user-select: none;
-`;
-
-const Title = styled.h3`
-  margin: 0;
-  text-transform: uppercase;
 `;
 
 const Text = styled.p`
@@ -53,9 +49,9 @@ function InstructionsModal({ isOpen, onClose }: InstructionsModalProps) {
 
   return (
     <Wrapper isOpen={isOpen} data-testid="instructions-modal">
-      <Title data-testid="instructions-modal-title">
+      <ModalTitle data-testid="instructions-modal-title">
         {titleText}
-      </Title>
+      </ModalTitle>
       <Text data-testid="instructions-modal-text">
         <Trans i18nKey={strings.INSTRUCTIONS_MODAL_TEXT} components={[<strong />]} />
       </Text>

--- a/src/components/LanguageModal.tsx
+++ b/src/components/LanguageModal.tsx
@@ -30,7 +30,7 @@ const LanguagesList = styled.div`
   padding: 16px 0 24px 0;
 `;
 
-const CloseButton = styled(ModalButton)`
+const ModalCloseButton = styled(ModalButton)`
   background-color: #DC7E13;
 
   &:active {
@@ -87,9 +87,9 @@ function LanguageModal({ isOpen, onClose }: LanguageModalProps) {
           />
         ))}
       </LanguagesList>
-      <CloseButton onClick={onClose} data-testid="language-modal-close-button">
+      <ModalCloseButton onClick={onClose} data-testid="language-modal-close-button">
         {closeButtonText}
-      </CloseButton>
+      </ModalCloseButton>
     </Wrapper>
   );
 };

--- a/src/components/LanguageModal.tsx
+++ b/src/components/LanguageModal.tsx
@@ -6,6 +6,7 @@ import strings from '../config/strings';
 import { updateDOMLanguage } from '../utils/i18n';
 import LanguageItem from './LanguageItem';
 import ModalButton from './ModalButton.styles';
+import ModalTitle from './ModalTitle.styles';
 
 const Wrapper = Modal.styled`
   width: 80vmin;
@@ -19,11 +20,6 @@ const Wrapper = Modal.styled`
   border: 2px solid #DC7E13;
   border-radius: 15px;
   user-select: none;
-`;
-
-const Title = styled.h3`
-  margin-top: 0;
-  text-transform: uppercase;
 `;
 
 const LanguagesList = styled.div`
@@ -77,9 +73,9 @@ function LanguageModal({ isOpen, onClose }: LanguageModalProps) {
 
   return (
     <Wrapper isOpen={isOpen} data-testid="language-modal">
-      <Title data-testid="language-modal-title">
+      <ModalTitle data-testid="language-modal-title">
         {titleText}
-      </Title>
+      </ModalTitle>
       <LanguagesList data-testid="language-modal-languages-list">
         {availableLanguages.map(({ code, selected, string }: AvailableLanguage) => (
           <LanguageItem

--- a/src/components/ModalTitle.styles.tsx
+++ b/src/components/ModalTitle.styles.tsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+const ModalTitle = styled.h3`
+  margin: 0;
+  text-transform: uppercase;
+`;
+
+export default ModalTitle;

--- a/src/components/WakeLockModal.tsx
+++ b/src/components/WakeLockModal.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import Modal from 'styled-react-modal';
 import strings from '../config/strings';
 import ModalButton from './ModalButton.styles';
+import ModalTitle from './ModalTitle.styles';
 
 const Wrapper = Modal.styled`
   width: 80vmin;
@@ -16,11 +17,6 @@ const Wrapper = Modal.styled`
   border: 2px solid #0D58BB;
   border-radius: 15px;
   user-select: none;
-`;
-
-const Title = styled.h3`
-  margin-top: 0;
-  text-transform: uppercase;
 `;
 
 const Text = styled.p`
@@ -56,9 +52,9 @@ function WakeLockModal({ isOpen, onClose }: WakeLockModalProps) {
 
   return (
     <Wrapper isOpen={isOpen} data-testid="wake-lock-modal">
-      <Title data-testid="wake-lock-modal-title">
+      <ModalTitle data-testid="wake-lock-modal-title">
         {titleText}
-      </Title>
+      </ModalTitle>
       <Text data-testid="wake-lock-modal-feature-text">
         <Trans i18nKey={strings.WAKE_LOCK_MODAL_FEATURE} components={[<strong />]} />
       </Text>

--- a/src/components/WakeLockModal.tsx
+++ b/src/components/WakeLockModal.tsx
@@ -30,7 +30,7 @@ const SupportText = styled(Text)`
   color: #9E9E9E;
 `;
 
-const CloseButton = styled(ModalButton)`
+const ModalCloseButton = styled(ModalButton)`
   background-color: #0D58BB;
 
   &:active {
@@ -64,9 +64,9 @@ function WakeLockModal({ isOpen, onClose }: WakeLockModalProps) {
       <SupportText data-testid="wake-lock-modal-clarification-text">
         {supportText}
       </SupportText>
-      <CloseButton onClick={onClose} data-testid="wake-lock-modal-close-button">
+      <ModalCloseButton onClick={onClose} data-testid="wake-lock-modal-close-button">
         {closeButtonText}
-      </CloseButton>
+      </ModalCloseButton>
     </Wrapper>
   );
 };


### PR DESCRIPTION
### Description

This pull request refactors the `<InstructionsModal />`, `<LanguageModal />`, and `<WakeLockModal />` components to use the new styled `<ModalTitle />` component, which is shared across components and contains the common styles for a modal's title.

Additionally, all modal's buttons were renamed from `<CloseButton />` to `<ModalCloseButton />` to have a more appropriate name according it's functionality.