### PR TITLE
test: improve round screen unit tests

### DIFF
--- a/src/screens/RoundScreen.tsx
+++ b/src/screens/RoundScreen.tsx
@@ -38,7 +38,7 @@ function RoundScreen() {
   return (
     <Wrapper role="region" onClick={toggleDirection}>
       <RoundDirectionArrow role="checkbox" aria-checked={roundDirection}>
-        <SlimSpinArrow title="arrow" />
+        <SlimSpinArrow role="img" />
       </RoundDirectionArrow>
     </Wrapper>
   );

--- a/src/screens/__tests__/RoundScreen.test.tsx
+++ b/src/screens/__tests__/RoundScreen.test.tsx
@@ -1,19 +1,49 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import RoundScreen from '../RoundScreen';
 
-test('renders the round screen component and toggles the direction of the round', () => {
+test('renders the round screen component', () => {
   render(
     <RoundScreen />
   );
 
-  expect(screen.queryByTitle(/arrow/i)).toBeInTheDocument();
+  expect(screen.queryByRole('region')).toBeInTheDocument();
+  expect(screen.queryByRole('img')).toBeInTheDocument();
   
   const roundDirectionArrow = screen.getByRole('checkbox');
   expect(roundDirectionArrow.getAttribute('aria-checked')).toEqual("true");
+});
+
+test('renders the round screen component and toggles the direction of the round once', () => {
+  render(
+    <RoundScreen />
+  );
   
-  // Toggle direction
   const wrapper = screen.getByRole('region');
+  const roundDirectionArrow = screen.getByRole('checkbox');
+  expect(roundDirectionArrow.getAttribute('aria-checked')).toEqual("true");
+  
+  // Toggle direction once
   act(() => { fireEvent.click(wrapper); });
 
   expect(roundDirectionArrow.getAttribute('aria-checked')).toEqual("false");
+});
+
+test('renders the round screen component and toggles the direction of the round twice', () => {
+  render(
+    <RoundScreen />
+  );
+  
+  const wrapper = screen.getByRole('region');
+  const roundDirectionArrow = screen.getByRole('checkbox');
+  expect(roundDirectionArrow.getAttribute('aria-checked')).toEqual("true");
+  
+  // Toggle direction once
+  act(() => { fireEvent.click(wrapper); });
+
+  expect(roundDirectionArrow.getAttribute('aria-checked')).toEqual("false");
+  
+  // Toggle direction twice
+  act(() => { fireEvent.click(wrapper); });
+
+  expect(roundDirectionArrow.getAttribute('aria-checked')).toEqual("true");
 });


### PR DESCRIPTION
### Description

This pull request updates the `<RoundScreen />` markup and unit tests that complies with the latest changes.

Additionally, we noticed that the `<RoundScreen />`'s unit tests wasn't covering common-case scenarios like toggling not once but twice the round's direction arrow. It may be "trivial" upon usage, but having the unit tests makes the code more reliable.